### PR TITLE
Changes and Updates

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>svg2tikz</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.python.pydev.PyDevBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.python.pydev.pythonNature</nature>
+	</natures>
+</projectDescription>

--- a/.pydevproject
+++ b/.pydevproject
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?eclipse-pydev version="1.0"?><pydev_project>
+<pydev_property name="org.python.pydev.PYTHON_PROJECT_INTERPRETER">Default</pydev_property>
+<pydev_property name="org.python.pydev.PYTHON_PROJECT_VERSION">python interpreter</pydev_property>
+</pydev_project>

--- a/.settings/org.eclipse.core.resources.prefs
+++ b/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding//svg2tikz/extensions/tikz_export.py=utf-8

--- a/README.md
+++ b/README.md
@@ -1,8 +1,20 @@
-*This project is not under active development.*
-
 # SVG2TikZ
 
 SVG2TikZ, formally known as Inkscape2TikZ ,are a set of tools for converting SVG graphics to TikZ/PGF code. 
 This project is licensed under the GNU GPL  (see  the [LICENSE](/LICENSE) file).
+
+## Changes, Bug fixes and Known Problems from the original
+
+- Now images can also be exported to tikz
+- Added a variable `/def /globalscale` to the output tikz document (standalone and tikz figure)
+- `/globalscale` when changed will scale the tikzfigure by transforming the vector coordinates.
+- `/globalscale` when changed will scale the tikzfigure by scaling the embedded images
+- The path element was not exported in correct coordinates. This is fixed
+- Added an entry to specify the path to be removed from absolute paths in the images. This is useful to work in a latex project directly
+
+Known Problems
+- Currently only images that are "linked" in svg are exported. Base64 embed is not yet supported so avoid choosing embed option
+- Grouped elements will not work. So ungroup everything
+- Transformation like rotation is not working
 
 More documentation can be found in the [docs/](/docs/index.rst) directory.

--- a/svg2tikz/extensions/tikz_export_effect.inx
+++ b/svg2tikz/extensions/tikz_export_effect.inx
@@ -22,6 +22,10 @@
             <param name="wrap" type="boolean" _gui-text="Wrap paths">true</param>
             <param name="indent" type="boolean" _gui-text="Indent groups">true</param>
             <param name="output" type="string" _gui-text="Output filename">none</param>
+            
+            <param name="latexpathtype" type="boolean" _gui-text="Path comply for tikz mode">false</param>
+            <param name="removeabsolute" type="string" _gui-text="Remove from path"></param>
+            
             <param name="verbose" type="boolean" _gui-text="Verbose output">false</param>
         </page>
         <page name="help" _gui-text="Help">


### PR DESCRIPTION
### Changes, Bug fixes and Known Problems

1- Finished with export of images in svg to tikz.
2 - Added a variable `/def /globalscale` to the output tikz document (standalone and tikz figure)
3 - `/globalscale` when changed will scale the tikzfigure by transforming the vector coordinates.
4 - `/globalscale` when changed will scale the tikzfigure by scaling the embedded images
5 - The path element was not exported in correct coordinates. This is fixed
6 - Added an entry to specify the path to be removed from absolute paths in the images. This is useful to work in a latex project directly

Known Problems
1 - Currently only images that are "linked" in svg are exported. Base64 embed is not yet supported so avoid choosing embed option
2 - Grouped elements will not work. So ungroup everything
3 - Transformation like rotation is not working